### PR TITLE
Add chapter on creating an open source product strategy

### DIFF
--- a/Creating_a_product_strategy.adoc
+++ b/Creating_a_product_strategy.adoc
@@ -4,7 +4,7 @@ Dave Neary
 
 "Should we open source this project?"
 
-This brief won't answer that question for you. But it _will_ outline some considerations you should make as you answer the question when it arises.
+This chapter won't answer that question for you. But it _will_ outline some considerations you should make as you answer the question when it arises.
 
 First, ask yourself why you are considering an open source approach. Before committing to creating and maintaining an open source project, understand _why_ open sourcing the project will help you or your organization achieve certaion goals. Identifying those benefits is the first step in creating an open source strategy.
 

--- a/Creating_a_product_strategy.adoc
+++ b/Creating_a_product_strategy.adoc
@@ -1,0 +1,53 @@
+= Creating an Open Source Product Strategy
+Dave Neary
+2018-04-19
+
+"Should we open source this project?"
+
+This brief won't answer that question for you. But it _will_ outline some considerations you should make as you answer the question when it arises.
+
+First, ask yourself why you are considering an open source approach. Before committing to creating and maintaining an open source project, understand _why_ open sourcing the project will help you or your organization achieve certaion goals. Identifying those benefits is the first step in creating an open source strategy.
+
+== Understand the economics of open source
+
+Open source is not a business model. It is a way to develop software collaboratively and increase a project's distribution and reach by lowering acquisition costs. To understand the business rationale that makes an open source strategy appealing, consider these economic principles:
+
+- *Reducing the price of a good increases the demand for it.* In the case of open source, lowering the cost of acquisition maximizes demand and, therefore, project adoption. Note that the cost of adoption is not only monetary; it also includes the time and effort needed to adopt and migrate from whatever solution you're currently using.
+
+- *When the price of one good decreases, demand for its substitutes also decreases.* Open source projects can undermine established proprietary software companies by being convenient to adopt at a lower cost. This principle explains how open source can be an agent for market disruption. Disruption is an opportunity to capitalize on the adoption of alternatives and grow another market.
+
+- *All else being equal, when the price of a good decreases, demand for its complements increases.* Every successful commercial open source strategy is based on this principle. If your goal is revenue, then you will need to determine the complements to the software that you 'll be releasing as open source. Those complements should provide additional value to customers.
+
+When establishing an open source strategy, your goal is to connect these principles with a concrete business goal.
+
+== Define your team and the field
+
+Creating a strategy requires input and buy-in from multiple stakeholders.
+
+- *Strike a balance* between involving too many people at an early stage and ensuring buy-in from a diverse group of people from the start.
+
+- *Organize your stakeholders using a model of growing, concentric circles.* Identify a core team that shares draft proposals early and often and engages with additional groups to gain awareness of concerns or constraints. Involving these stakeholders early will help you catch and address deal-breaking issues early.
+
+- *Ensure that all stakeholders share an understanding of the problem your work is addressing.* Develop your understanding of both the landscape in which the project operates and the relative benefit of investing in one option over others.
+
+== Generate a draft strategy proposal
+
+Next, compose a strategy proposal document. It should contain:
+
+- *An elevator pitch,* a high-level description of the open source project's goal and a short explanation of how the project benefits the sponsoring company. No two projects will have identical goals, so no two projects will share exactly the same product strategy.
+
+- *A business rationale,* a definition of how success for the community project translates into success for the company or product team. For example, "Wide adoption of this project will help people glean more benefit from our other products," or "An open source reference implementation of a standard will encourage adoption of the standard by multiple companies, enabling a network effect for others building on top of the standard."
+
+- *A high-level execution plan,* including key performance indicators (KPIs) that will be important for determining success. Project goals suggest these KPIs. For example, if your goal is de facto standard implementation with wide adoption, then you might measure the number of vendors distributing standard-compliant implementations. If your goal is market education, then the performance of introductory documentation, learning paths, tutorials, and magazine articles will be your top priority.
+
+== Move from strategy to action
+
+Strategy documents are useful if they affect action by allowing individuals to make local decisions in support of global goals. Communicating your strategy is therefore crucial to achieving strategic ends. Everyone should understand how their work impacts the open source strategy. When the entire organization understands the project's goal, reaching consensus on budget and resource allocation is much easier.
+
+- *Continually monitor and communicate progress toward project goals.* If fostering a diverse group of codevelopers is your community goal, then celebrate contributions from new participants and include growth figures in your monthly newsletter.
+
+- *Allocate resources in a way that makes success possible.* If your goal is to move an entire industry from a proprietary competitor to an open source project, and you have one person working part time to promote the open source project, then your chances of success are low.
+
+- *Ensure that your strategy is a living document.* Revisit it regularly with key stakeholders to ensure that your open source strategy stays fresh and relevant.
+
+Crafting an open source strategy requires representing all key constituencies in the development process to achieve buy-in, exploring reasons why open sourcing makes sense for the organization 's goals, ensuring you are measuring the right things to gauge your success, and preparing to pivot if necessary. Do all of this well, and you can turn everyone involved into an advocate for the open source project.


### PR DESCRIPTION
This PR suggests [recent writing on open source product strategy development from @dneary](https://www.redhat.com/en/resources/creating-an-open-source-product-strategy-brief).

Apologies for including the README, yet again, in the PR. Not sure how that happened. I'll figure this out some day.