### PR TITLE
Removing unintentional defer-to-experts bias

### DIFF
--- a/marketing/SCaLE_18x_Workshop-_-06_March_2020--content.adoc
+++ b/marketing/SCaLE_18x_Workshop-_-06_March_2020--content.adoc
@@ -9,12 +9,12 @@ participation process. There are activities for short (30 to 60
 minutes) and longer (1 to 4 hours) periods of time, so you can fit
 this into your busy Friday at SCaLE.
 
-If you are a practitioner of open source community management, you are
+If you are a member of an open source community or practitioner of community management, you are
 likely familiar with how often you need to provide the same advice and
-guidance to members of your community.
+guidance to new and even experienced members of your community.
 
-This guide is *for* community managers, written *by* community
-managers. It is a collaboration, a sharing of opinions and practices,
+While this guide is primarily for helping perform the tasks of community management, it is written by a range of community
+managers and other experienced practitioners. It is a collaboration, a sharing of opinions and practices,
 so you get a diverse and wider-ranging set of viewpoints and
 experience informing the guide.
 


### PR DESCRIPTION
@shaunix pointed out to me in chat that especially the fourth paragraph wasn't welcoming to people who don't self identify as "community managers". This for me was what we call "a head slapping moment", as I metaphorically struck my head in realization that of course we mean this to be not just informed by anyone with experience--not only community managers--but that we want it to be used by anyone in open source communities and not exclusively community managers. These changes should reflect that intention.