### PR TITLE
Split Legal & Governance chapter into two discrete chapters

### DIFF
--- a/OUTLINE.adoc
+++ b/OUTLINE.adoc
@@ -12,14 +12,18 @@
 .. What is a contribution
 .. Getting organized
 .. Onboarding
-.. Legal and governance
+.. Community governance
 .. Community roles
 .. Migrating code
 . Measuring Success
 .. Defining healthy communities
 .. Developing a metrics plan
 .. Announcing software releases
+. Community manager self-care
+.. _New section from FOSDEM community brainstorm, chapters TBD_
 . Avoiding Pitfalls and Learning From Mistakes
-. References and Case Studies
+.. Legal issues in communities
+.. Open source practitioners interviews; transcripts and "why" stories
+.. Home to all extra stories
 .. References
 .. Case studies

--- a/avoiding_pitfalls_section.adoc
+++ b/avoiding_pitfalls_section.adoc
@@ -1,3 +1,4 @@
 . Avoiding Pitfalls and Learning From Mistakes
-.. Home to all extra stories
+.. Legal issues in communities
 .. Open source practitioners interviews; transcripts and "why" stories
+.. Home to all extra stories

--- a/community_governance.adoc
+++ b/community_governance.adoc
@@ -1,4 +1,4 @@
-= Legal and governance
+= Community Governance
 Authors: Dave Neary <dneary@redhat.com>
 Updated: 2019-12-31
 

--- a/self-care_section.adoc
+++ b/self-care_section.adoc
@@ -1,2 +1,2 @@
-= Community Manager Self-Care
-. _New section from FOSDEM BoF, chapters TBD_
+. Community manager self-care
+.. _New section from FOSDEM community brainstorm, chapters TBD_


### PR DESCRIPTION
Following recent contributor discussion in #30, this PR suggests splitting the "Legal & Governance" chapter into two discrete chapters on each of those topics, respectively.

It also adjusts book outlines accordingly, accounting too for some recent changes to section organization(s).