### PR TITLE
Updates to latest in process, esp for PRs

### DIFF
--- a/PROCESS.adoc
+++ b/PROCESS.adoc
@@ -23,7 +23,7 @@ Just follow these steps:
 . Add a file name in the name field
 . Copy the text into the Edit new file field
 . In the `Commit new file` section, add a short commit message.
-. In the `Comment` field, add a short message with the number of the issue associated with the chapter. (for example, "per discussion in #_XX_")
+. In the `Comment` field, add a short message with the number of the issue associated with the chapter (for example, "per discussion in #_XX_").
 . Click the `Create a new branch for this commit and start a new pull request` radio button. You can use the suggested branch name.
 . Click `Propose New File`. The `Open a Pull Request` window will open.
 . Click the gear icon in the Reviewers pane in the right column of the page.
@@ -46,7 +46,7 @@ When review is complete and the pull request merged, reviewers should perform on
 
 == Editing in The Open Source Way
 
-When a chapter has been merged into the Main branch, it is ready to procede through [the editorial process](https://github.com/theopensourceway/guidebook/blob/master/EDITORIAL.md). This process will involve the following steps (or "phases"):
+When a chapter has been merged into the Main branch, it is ready to procede through https://github.com/theopensourceway/guidebook/blob/master/EDITORIAL.md[the editorial process]. This process will involve the following steps (or "phases"):
 
 . Deverlopment edit
 . Subject matter review

--- a/PROCESS.adoc
+++ b/PROCESS.adoc
@@ -1,9 +1,10 @@
 = The Open Source Way Publishing Process 
 
 The Open Source Way's project workflow is largely dependent on the functionality of the GitHub platform.
-GitHub is a web-based, distributed version control tool that enables content creators build and collaborate on text-based creations (code, prose) wherever they can connect to the internet.
+GitHub is a web-based, distributed version control tool that enables content creators to build and collaborate on text-based creations (code, prose) wherever they can connect to the internet.
 Before beginning work on The Open Source Way, contributors must have a https://github.com/[GitHub account].
 All work done on The Open Source Way will be done within the https://github.com/theopensourceway/guidebook[guidebook repository] of the https://github.com/theopensourceway[The Open Source Way organization].
+This work will be under the https://github.com/theopensourceway/guidebook/blob/master/LICENSE.md[project's license].
 
 The Open Source Way editorial process is divided into two distinct phases: **contribution** and **editorial**.
 
@@ -34,12 +35,13 @@ If it meets inclusion criteria, project maintainers will merge it into the proje
 
 == Reviewing a contribution
 
-When receiving a request to review an initial contribution, reviewers should use The Open Source Way guidelines to approve the chapter for further editing.
+When receiving a request to review an initial contribution ("Draft Review" column), reviewers should use The Open Source Way https://github.com/theopensourceway/guidebook/blob/master/EDITORIAL.md[editorial guidelines] to approve the chapter for further editing.
 
-When review is complete and the pull request merged, reviewers should perform one  additional step so subsequent editors can find the file quickly.
+When review is complete and the pull request merged, reviewers should perform one additional set of steps so subsequent editors can find the file quickly.
 
 . Open the merged file in GitHub.
 . Copy and paste the full URL for the file into the relevant issue's comment section.
+. On the right side of the issue, link the issue to the merged pull request.
 . Click `Comment`.
 
 == Editing in The Open Source Way
@@ -58,5 +60,17 @@ Each pass requires a different form of editorial and knowledge expertise, but in
 . Click the Edit icon in the upper right section of the file's page.
 . Perform the appropriate editorial work on the chapter
 . Complete at least the first field in the "Commit changes" field beneath the editing pane. Be sure to describe the type of editorial with you've performed (for example, "perform a development edit" or "formatting pass complete")
-. Select the "Commit directly to ``main`` branch radio button
+. Select the "Create a **new branch** for this commit and start a pull request." radio button
+  * When filling out the pull request, make sure to link the pull request back against the original issue. The issue will collect pull requests as it moves through the editorial columns.
 . Click the ``Commit changes`` button
+. Another member of the Editorial team checks your change and merges the commit into the main branch; they also need to reopen the issue assigned to the chapter, which is closed automatically when the pull request is merged.
+
+An alternate process goes like this:
+
+. A previous editor will link issue that is visible on the project https://github.com/theopensourceway/guidebook/projects/1[Editorial Board] to an open pulle request.
+. An editor then uses the pull request tooling to edit and comment. **FIXME: better instructions needed**
+. When the edit review is complete, the editor merges the pull request into the Main branch.
+. The editor then needs to reopen the issue that is automatically closed when the pull request was merged.
+. Editor can confirm that the issue moved along to the next column in the Editorial Board, if appropriate. 
+
+You can read more about pull requests in the https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests[GitHub documentation].

--- a/PROCESS.adoc
+++ b/PROCESS.adoc
@@ -11,7 +11,7 @@ The Open Source Way editorial process is divided into two distinct phases: **con
 **Contribution** involves the work of creation.
 Contributors propose content in individual https://help.github.com/en/github/getting-started-with-github/github-glossary#branch["branches,"] then ask project maintainers to review it and, ultimately, to merge the work into the project.
 
-**Editorial** is the process of refining contributed content via numerous editorial "passes."
+**Editorial** is the process of refining contributed content via numerous editorial phases.
 We perform this work primarily through GitHub's issue-tracking tools, using GitHub's web interface. 
 
 == Contributing to The Open Source Way
@@ -46,12 +46,12 @@ When review is complete and the pull request merged, reviewers should perform on
 
 == Editing in The Open Source Way
 
-When a chapter has been merged into the Main branch, it is ready to procede through the editorial process. This process will involve the following steps (or "passes"):
+When a chapter has been merged into the Main branch, it is ready to procede through [the editorial process](https://github.com/theopensourceway/guidebook/blob/master/EDITORIAL.md). This process will involve the following steps (or "phases"):
 
-. Subject-matter expert (SME) pass
-. Formatting pass
-. Development pass
-. Copy edit pass
+. Deverlopment edit
+. Subject matter review
+. Copy edit
+. Technical edit
 
 Each pass requires a different form of editorial and knowledge expertise, but in each pass the general editorial workflow remains the same. It looks like this:
 
@@ -59,10 +59,10 @@ Each pass requires a different form of editorial and knowledge expertise, but in
 . Click the URL for the file to be edited. The file's page will open.
 . Click the Edit icon in the upper right section of the file's page.
 . Perform the appropriate editorial work on the chapter
-. Complete at least the first field in the "Commit changes" field beneath the editing pane. Be sure to describe the type of editorial with you've performed (for example, "perform a development edit" or "formatting pass complete")
-. Select the "Create a **new branch** for this commit and start a pull request." radio button
+. Complete at least the first field in the ``Commit changes`` field beneath the editing pane. Be sure to describe the type of editorial with you've performed (for example, "perform a development edit" or "formatting pass complete")
+. Select the ``Create a new branch for this commit and start a pull request`` radio button.
   * When filling out the pull request, make sure to link the pull request back against the original issue. The issue will collect pull requests as it moves through the editorial columns.
-. Click the ``Commit changes`` button
+. Click the ``Commit changes`` button.
 . Another member of the Editorial team checks your change and merges the commit into the main branch; they also need to reopen the issue assigned to the chapter, which is closed automatically when the pull request is merged.
 
 An alternate process goes like this:


### PR DESCRIPTION
We've tweaked and adjusted the process a bit since the last pass at this document.
- We are supporting edit/reviews in the pull request.
- We can support an edit being made as a pull request, especially useful for SME reviews.
- This adds steps to ensure the issue is reopened after the linked PR merge closes it.
- NEW Just today we added the plan to continue linking pull requests as an issue moves through the columns on the editorial board. The issue will collect closed PRs, and have only one possible PR open at a time. The merging of the one open PR then moves it along to the next column; if more than one is open for some reason, the issue will have to be reopened and probably moved back a column manually. One benefit here is that the issue then cleaning shows how to find all the discussions for a particular issue, whether they are in the issue itself or in the related pull requests. This allows editors to do a full edit and merge, and have that just follow the issue in it's unique and finable commit, without having to futz with pointing to where in the repo history your specific edit is ready for the writer to review.